### PR TITLE
feat: drum-harvest.py improvements

### DIFF
--- a/source/code/drum-harvest.py
+++ b/source/code/drum-harvest.py
@@ -6,9 +6,6 @@
 # already downloaded, but first you must remove the
 # files/temp directory.
 
-# import logging
-# from http.client import HTTPConnection
-# import sys
 import json
 from pathlib import Path
 import argparse
@@ -98,15 +95,20 @@ def harvest_item(item):
     print(f'{uuid}: {title}')
 
     # Determine the item directory, skip if exists
-    dir = Path('files') / Path(uuid)
+    dir = args.directory / Path(uuid)
     if dir.exists():
         return
 
-    # Determine the temp directory, error if exists
-    temp_dir = dir.parent / Path('temp')
+    # Setup the temporary item directory
+    temp_dir = args.directory / Path('temp')
 
     if temp_dir.exists():
-        raise Exception(f'{temp_dir} exists; please review and delete it to proceed')
+        if args.delete_temp:
+            import shutil
+            shutil.rmtree(temp_dir)
+            print(f'Deleted existing temp directory: {temp_dir}')
+        else:
+            raise Exception(f'{temp_dir} exists; please review and delete it to proceed')
 
     temp_dir.mkdir(parents=True)
 
@@ -169,6 +171,16 @@ if __name__ == "__main__":
                         default=2.0,
                         help='Delay in seconds between requests (default: 2.0)')
 
+    parser.add_argument('--delete-temp',
+                        action='store_true',
+                        default=False,
+                        help='Delete the temporary item directory if it exists (default: False)')
+
+    parser.add_argument('--directory',
+                        type=Path,
+                        default=Path('harvest'),
+                        help='Directory to store harvested items (default: harvest)')
+
     global args
     args = parser.parse_args()
 
@@ -176,6 +188,12 @@ if __name__ == "__main__":
     for option in args.harvest:
         if option not in harvest_options:
             parser.error(f'Invalid --harvest option: {option if option else "<empty>"}')
+
+    # Validate the directory path
+    if not args.directory.exists():
+        parser.error(f'Directory does not exist: {args.directory}')
+    elif not args.directory.is_dir():
+        parser.error(f'Invalid --directory option: {args.directory} is not a directory')
 
     print(args)
 

--- a/source/code/drum-harvest.py
+++ b/source/code/drum-harvest.py
@@ -6,11 +6,13 @@
 # already downloaded, but first you must remove the
 # files/temp directory.
 
-import logging
-from http.client import HTTPConnection
-import sys
+# import logging
+# from http.client import HTTPConnection
+# import sys
 import json
 from pathlib import Path
+import argparse
+import time
 
 import requests
 
@@ -109,11 +111,14 @@ def harvest_item(item):
     temp_dir.mkdir(parents=True)
 
     # Write the item file
-    with (temp_dir / Path(f'{uuid}.json')).open(mode='w', encoding='utf-8') as f:
-        json.dump(item, f)
+    if 'item-metadata' in args.harvest:
+        with (temp_dir / Path(f'{uuid}.json')).open(mode='w', encoding='utf-8') as f:
+            json.dump(item, f)
+            f.write('\n')
 
     # Harvest this item's bundles
-    harvest_bundles(item, temp_dir)
+    if 'files' in args.harvest:
+        harvest_bundles(item, temp_dir)
 
     # Rename the temp directory to the item directory
     # This indicates the downloads for this item are complete
@@ -128,7 +133,7 @@ def harvest_items():
     # Iterate over paged results
     while True:
 
-        response = requests.get(items_url)
+        response = requests.get(items_url, params={'size': 100})
 
         if not response.ok:
             print(f'Error reading response: {response}')
@@ -143,8 +148,35 @@ def harvest_items():
         if 'next' in response['_links']:
             items_url = response['_links']['next']['href']
         else:
+            print("Harvest complete")
             break
 
+        # Delay between requests
+        if args.delay > 0:
+            time.sleep(args.delay)
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Harvest items from DRUM')
+
+    harvest_options = ['item-metadata', 'files']
+    parser.add_argument('--harvest',
+                        type=lambda s: [item.strip() for item in s.split(',')],
+                        default=', '.join(harvest_options),
+                        help=f'Comma-separated list of data to harvest: (default: {", ".join(harvest_options)})')
+
+    parser.add_argument('--delay',
+                        type=float,
+                        default=2.0,
+                        help='Delay in seconds between requests (default: 2.0)')
+
+    global args
+    args = parser.parse_args()
+
+    # Validate harvest options
+    for option in args.harvest:
+        if option not in harvest_options:
+            parser.error(f'Invalid --harvest option: {option if option else "<empty>"}')
+
+    print(args)
+
     harvest_items()

--- a/source/code/drum-harvest.py
+++ b/source/code/drum-harvest.py
@@ -168,7 +168,25 @@ def harvest_items():
             time.sleep(args.delay)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Harvest items from DRUM')
+
+    parser = argparse.ArgumentParser(description='Harvest items from DRUM',
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     epilog='''
+Example file structure for two items in the <harvest> directory:
+
+harvest
+├── 065fa8e1-e9ad-4c4a-ab8e-0f4e34733f47 # Item ID
+│   ├── 065fa8e1-e9ad-4c4a-ab8e-0f4e34733f47.json # Item metadata
+│   └── Puchtel et al. (2018 Geochimical et Cosmochimica Acta).pdf # Downloaded file for the item
+├── 2c7918c8-17c7-449d-ba02-28b92c252cac
+│   ├── 24SS_URSP673_15MinuteNeighborhoods_FinalPresentation_POST.pdf
+│   ├── 24SS_URSP673_15MinuteNeighborhoods_FinalReport_POST.pdf
+│   └── 2c7918c8-17c7-449d-ba02-28b92c252cac.json
+
+If this script is restarted, it will skip any items already downloaded, but
+first you must remove the {directory}/temp directory, which may contain files
+harvested from an item which was interrupted in progress.
+''')
 
     harvest_options = ['item-metadata', 'files']
     parser.add_argument('--harvest',

--- a/source/code/drum-harvest.py
+++ b/source/code/drum-harvest.py
@@ -212,7 +212,7 @@ harvested from an item which was interrupted in progress.
     parser.add_argument('--collection-id',
                         type=str,
                         default=None,
-                        help='Limit harvesting to items in a collection (default: all items)')
+                        help='Limit harvesting to items in a collection (default: None)')
 
     global args
     args = parser.parse_args()

--- a/source/code/drum-harvest.py
+++ b/source/code/drum-harvest.py
@@ -130,7 +130,10 @@ def harvest_item(item):
 def harvest_items():
     ''' Browse over all items, harvest each one '''
 
-    items_url = ENDPOINT + '/discover/browses/title/items'
+    if args.collection_id:
+        items_url = ENDPOINT + f'/discover/search/objects?configuration=collection&scope={args.collection_id}'
+    else:
+        items_url = ENDPOINT + '/discover/browses/title/items'
 
     # Iterate over paged results
     while True:
@@ -143,9 +146,16 @@ def harvest_items():
 
         response = json.loads(response.text)
 
+        if args.collection_id:
+            response = response['_embedded']['searchResult']
+
         # Iterate over the returned items
-        for item in response['_embedded']['items']:
-            harvest_item(item)
+        if args.collection_id:
+            for object in response['_embedded']['objects']:
+                harvest_item(object['_embedded']['indexableObject'])
+        else:
+            for item in response['_embedded']['items']:
+                harvest_item(item)
 
         if 'next' in response['_links']:
             items_url = response['_links']['next']['href']
@@ -181,6 +191,11 @@ if __name__ == "__main__":
                         default=Path('harvest'),
                         help='Directory to store harvested items (default: harvest)')
 
+    parser.add_argument('--collection-id',
+                        type=str,
+                        default=None,
+                        help='Limit harvesting to items in a collection (default: all items)')
+
     global args
     args = parser.parse_args()
 
@@ -195,6 +210,8 @@ if __name__ == "__main__":
     elif not args.directory.is_dir():
         parser.error(f'Invalid --directory option: {args.directory} is not a directory')
 
-    print(args)
+    print("Harvest configuration:")
+    for arg, value in vars(args).items():
+        print(f"  {arg}: {value}")
 
     harvest_items()


### PR DESCRIPTION
Add command line arguments, with new set of options:

```
usage: drum-harvest.py [-h] [--harvest HARVEST] [--delay DELAY] [--delete-temp] [--directory DIRECTORY] [--collection-id COLLECTION_ID]

Harvest items from DRUM

options:
  -h, --help            show this help message and exit
  --harvest HARVEST     Comma-separated list of data to harvest: (default: item-metadata, files)
  --delay DELAY         Delay in seconds between requests (default: 2.0)
  --delete-temp         Delete the temporary item directory if it exists (default: False)
  --directory DIRECTORY
                        Directory to store harvested items (default: harvest)
  --collection-id COLLECTION_ID
                        Limit harvesting to items in a collection (default: None)

Example file structure for two items in the <harvest> directory:

harvest
├── 065fa8e1-e9ad-4c4a-ab8e-0f4e34733f47 # Item ID
│   ├── 065fa8e1-e9ad-4c4a-ab8e-0f4e34733f47.json # Item metadata
│   └── Puchtel et al. (2018 Geochimical et Cosmochimica Acta).pdf # Downloaded file for the item
├── 2c7918c8-17c7-449d-ba02-28b92c252cac
│   ├── 24SS_URSP673_15MinuteNeighborhoods_FinalPresentation_POST.pdf
│   ├── 24SS_URSP673_15MinuteNeighborhoods_FinalReport_POST.pdf
│   └── 2c7918c8-17c7-449d-ba02-28b92c252cac.json

If this script is restarted, it will skip any items already downloaded, but
first you must remove the {directory}/temp directory, which may contain files
harvested from an item which was interrupted in progress.
```

https://umd-dit.atlassian.net/browse/LIBITD-2586