### PR TITLE
fix: wrap FlexSearch section prefixes in list items

### DIFF
--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -1,3 +1,41 @@
+  {{- /*
+    Accessibility fix for Hextra's FlexSearch results. When a result carries a
+    section prefix, Hextra appends a bare <div class="hextra-search-prefix">
+    directly into the results <ul>, which violates WCAG 1.3.1 (a <ul> may only
+    directly contain <li>). Wrap those prefix divs in <li> as results render,
+    keeping the section headers in the a11y tree and the list valid. This is a
+    pre-existing theme issue, fixed here without forking Hextra's search script.
+    Retire this if Hextra fixes it upstream.
+  */ -}}
+  <script>
+    (function () {
+      function wrapPrefixes(ul) {
+        ul.querySelectorAll(':scope > .hextra-search-prefix').forEach(function (div) {
+          var li = document.createElement('li');
+          li.className = 'hextra-search-prefix-item';
+          div.parentNode.insertBefore(li, div);
+          li.appendChild(div);
+        });
+      }
+      function attach() {
+        var ul = document.querySelector('.hextra-search-results');
+        if (!ul || ul.dataset.umdWrapAttached) { return !!ul; }
+        ul.dataset.umdWrapAttached = '1';
+        var obs = new MutationObserver(function () {
+          obs.disconnect();
+          wrapPrefixes(ul);
+          obs.observe(ul, { childList: true });
+        });
+        obs.observe(ul, { childList: true });
+        wrapPrefixes(ul);
+        return true;
+      }
+      if (!attach()) {
+        var n = 0, iv = setInterval(function () { if (attach() || ++n > 60) clearInterval(iv); }, 100);
+      }
+    })();
+  </script>
+
   <!-- Matomo -->
   <script>
     var _paq = window._paq = window._paq || [];


### PR DESCRIPTION
Hextra's search appends a bare `<div class="hextra-search-prefix">` directly into the results `<ul>` when a result carries a section prefix. A `<ul>` may only directly contain `<li>`, so the section headers sit outside the list structure and the markup fails WCAG 1.3.1 (Info and Relationships).

A `MutationObserver` in `layouts/partials/custom/head-end.html` wraps those prefix divs in `<li>` as results render. No fork of Hextra's search script, and no CSS change — the wrapper carries no styling.

This is a pre-existing upstream Hextra issue, so the workaround should be retired if Hextra fixes it.

Extracted from #9, which is a draft prototype held pending a design-system decision. This fix is independent of that decision and applies to the site as it stands today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)