### PR TITLE
build: pin design system theme to the 4.0.1 tag

### DIFF
--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -20,12 +20,10 @@
     typography.css.
   */ -}}
   {{- /*
-    Pinned to the merge commit of LIBWEB-6781, which is currently the only
-    immutable ref that contains the split -- it landed on the 4.0.x branch and no
-    tag has been cut yet. Swap this for the tag (expected 4.0.1) when it lands;
-    it is the only line that needs to change.
+    Pinned to the 4.0.1 tag, the first release containing the LIBWEB-6781 layer
+    split. To move to a later release, change this line and nothing else.
   */ -}}
-  {{- $dsRef := "4dbe11007a5dfdfacae8ce5cc29d50fa5afe7286" -}}
+  {{- $dsRef := "4.0.1" -}}
   {{- $dsBase := printf "https://raw.githubusercontent.com/umd-lib/umdlib-design-system-theme/%s/css" $dsRef -}}
 
   {{- /*


### PR DESCRIPTION
The design system CSS was pinned to the LIBWEB-6781 merge commit SHA because no tag containing the CSS layer split existed yet. @jgottwig has cut 4.0.1, so this moves the pin to the tag.

`$dsRef` in `layouts/partials/custom/head-end.html` is the only line that changes.

## No change to the built output

The three files this site consumes are byte-identical between the two refs:

| file | sha256 (both refs) |
|---|---|
| `css/tokens.css` | `37281d15c32c…` |
| `css/utilities.css` | `3632d68b8edf…` |
| `css/fonts.css` | `42593a901bdc…` |

The four commits between the old SHA and the tag touch `templates/layout/html.html.twig` and `umdlib_umdds.libraries.yml` — Drupal-side asset loading, which this site does not consume.

## Verification

Clean build (`rm -rf public resources/_gen && hugo build`) succeeds against the tag, so the remote fetch resolves and the font-subset guard finds all three faces upstream. The emitted stylesheet keeps Barlow Condensed 700 italic and both Interstate faces, each with `font-display: swap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)