### PR TITLE
fix: stop the Docker build dropping assets/ and shipping an unstyled site

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Subtracted from "COPY . /build/". Denylist on purpose: a new Hugo input
+# directory works without anyone remembering to edit this file.
+#
+# "*" does not cross "/", so "*.md" matches README.md but not content/**/*.md.
+
+.git
+.gitignore
+.gitmodules
+.dockerignore
+Dockerfile
+
+# public/ especially: otherwise a local build gets copied in and served in
+# place of the one built here.
+public/
+resources/
+.hugo_build.lock
+build/
+
+.vscode/
+.claude/
+.agents/
+skills-lock.json
+
+# Repo-level Python harness only. The examples in static/code/ are published
+# by the site and must be copied.
+.venv/
+.python-version
+pyproject.toml
+uv.lock
+tox.ini
+test_python_examples.py
+__pycache__/
+
+# Harvested DRUM metadata and bitstreams. Working data, never part of the site.
+harvest/
+
+*.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,17 +15,14 @@ RUN echo 'export PATH=$PATH:/root/go/bin' >>  /root/.bashrc
 
 WORKDIR /build
 
-COPY archetypes /build/archetypes
-COPY content /build/content
-COPY i18n /build/i18n
-COPY layouts /build/layouts
-COPY static /build/static
-COPY themes /build/themes
-
-COPY hugo.yaml /build/hugo.yaml
-COPY go.mod /build/go.mod
-COPY go.sum /build/go.sum
-COPY Taskfile.yaml /build/Taskfile.yaml
+# Copy everything and let .dockerignore subtract. Do not go back to enumerating
+# the directories to include: that form silently dropped assets/, and no build
+# error was possible, because Hextra ships a zero-byte assets/css/custom.css
+# stub at the same path as our override -- the union filesystem resolves it
+# either way, so the site built cleanly with the whole brand shell unstyled.
+# A denylist fails safe: a forgotten entry copies a spare file rather than
+# losing a required one.
+COPY . /build/
 
 ARG HUGO_BASEURL=https://opendata.lib.umd.edu/
 ENV HUGO_BASEURL=$HUGO_BASEURL


### PR DESCRIPTION
The image built from `main` renders without the brand shell: no red university
strip, an unstyled header with both logo variants stacked, unstyled hero, cards
and footer. A local `hugo build` of the same commit is correct.

## Cause

The Dockerfile enumerated the directories to `COPY`. That list was complete when
written, but `assets/` was added later (0ee5893, #9) and never added to it, so
the image was built without `assets/css/custom.css` — which is where the whole
shell is defined.

Nothing failed, because nothing could. `assets/css/custom.css` is Hextra's
override hook and the theme ships a zero-byte stub at that path, so Hugo's union
filesystem resolves the import either way. The build exits 0 and the missing
styles only surface in QA.

## Fix

Replace the allowlist with `COPY .` plus a `.dockerignore`. This inverts the
failure direction: a forgotten entry now copies a spare file rather than
dropping a required one, and a new Hugo input directory works without anyone
remembering to edit the Dockerfile. The tracked payload is ~500K.

## Verification

Built the image and compared it against a local build of the same commit:

| Check | Result |
|---|---|
| Compiled stylesheet fingerprint | `main.min.e3f95003b07d0354….css` — identical |
| Brand shell selectors in image CSS | all 7 present (`umd-utility-bar`, `umd-header__inner`, `umd-header__logo-dark`, `umd-hero__headline`, `umd-cta`, `umd-card__headline`, `umd-footer__inner`) |
| Page inventory | identical, except nginx's own `50x.html` |

The broken build was reproduced first by building the Dockerfile's exact `COPY`
set against the full tree; it produced `main.min.1a431501cdeb5232….css`, matching
the fingerprint served by the QA image.

`*.md` in `.dockerignore` is root-only — `*` does not cross `/` — confirmed by
the identical page inventory above.
